### PR TITLE
Added percentage fee numerator and denominator.

### DIFF
--- a/serviceOwner.json.example
+++ b/serviceOwner.json.example
@@ -4,7 +4,7 @@
   "txOperatorMnemonic": "",
   "txOperatorMnemonicPw": "",
   "liliumFeeAddress": "",
-  "liliumFeeNanoErg": 5000000,
+  "liliumFeePercent": 5000000,
   "minTxOperatorFeeNanoErg": 1000000,
   "minerFeeNanoErg": 1523000,
   "nodeUrl": "http://213.239.193.208:9052",

--- a/src/main/resources/contracts/Lilium/BoxGuardScripts/StateContract.es
+++ b/src/main/resources/contracts/Lilium/BoxGuardScripts/StateContract.es
@@ -23,7 +23,8 @@
    // _singletonToken: Coll[Byte]
    // _priceOfNFT: Long
    // _liliumSigmaProp: SigmaProp
-   // _liliumFee: Long
+   // _liliumFeeNum: Long
+   // _liliumFeeDenom: Long
    // _minerFee: Long
    // _txOperatorFee: Long
 
@@ -144,7 +145,7 @@
          val validLiliumBox: Boolean = {
 
             allOf(Coll(
-               (liliumBoxOUT.value == _liliumFee),
+               (liliumBoxOUT.value == (_liliumFeeNum * _priceOfNFT) / _liliumFeeDenom),
                (liliumBoxOUT.propositionBytes == _liliumSigmaProp.propBytes)
             ))
 

--- a/src/main/scala/configs/conf.scala
+++ b/src/main/scala/configs/conf.scala
@@ -83,7 +83,7 @@ case class ServiceOwnerConfig(
     txOperatorMnemonic: String,
     txOperatorMnemonicPw: String,
     liliumFeeAddress: String,
-    liliumFeeNanoErg: Long,
+    liliumFeePercent: Long,
     minTxOperatorFeeNanoErg: Long,
     minerFeeNanoErg: Long,
     nodeUrl: String,

--- a/src/main/scala/mint/mintUtility.scala
+++ b/src/main/scala/mint/mintUtility.scala
@@ -45,9 +45,9 @@ class mintUtility(
   def convertERGLongToDouble(num: Long): Double = {
     val value = num * math.pow(10, -9)
     val x =
-      (math floor value * math.pow(10, num.toString.length + 2)) / math.pow(
+      (math floor value * math.pow(10, num.toString.length + 4)) / math.pow(
         10,
-        num.toString.length + 2
+        num.toString.length + 4
       )
     val bNum = math.BigDecimal(x)
     val finalNum = bNum.underlying().stripTrailingZeros()
@@ -159,7 +159,7 @@ class mintUtility(
       inputValue.append(input.getValue)
     }
 
-    println("Input Value: " + inputValue.sum)
+//    println("Input Value: " + inputValue.sum)
 //    inputValueIdeal.append(input0.getValue)
 //    inputValueIdeal.append(proxyInput.getValue)
 //    val buyerAmountPaid = 0.003
@@ -230,8 +230,8 @@ class mintUtility(
     val newStateBox: OutBox = {
       if (r6 + 1L == collectionMaxSize) { //last sale outbox
         println("Last Sale")
-        println("r6 + 1L = " + r6 + 1L)
-        println("collectionMaxSize: " + collectionMaxSize)
+//        println("r6 + 1L = " + r6 + 1L)
+//        println("collectionMaxSize: " + collectionMaxSize)
         outBoxObj.lastStateBox(
           stateContract,
           issuanceTree,
@@ -298,6 +298,8 @@ class mintUtility(
 
 //    val liliumFee = 5000000
 
+//    println("Lilium Fee: " + liliumFee)
+
     val liliumFeeAddress = new org.ergoplatform.appkit.SigmaProp(
       stateContract.getErgoTree
         .constants(31)
@@ -322,11 +324,11 @@ class mintUtility(
       }
     }
 
-    OutBox.foreach(o => println(o.getValue))
+//    OutBox.foreach(o => println(o.getValue))
 
     OutBox.foreach(o => outValue.append(o.getValue))
 
-    println("Output Value: " + outValue.sum)
+//    println("Output Value: " + outValue.sum)
 
     val unsignedTx: UnsignedTransaction = {
       if (hasSaleEnded) {

--- a/src/main/scala/utils/ContractCompile.scala
+++ b/src/main/scala/utils/ContractCompile.scala
@@ -82,7 +82,7 @@ class ContractCompile(ctx: BlockchainContext) {
       singletonToken: ErgoToken,
       priceOfNFTNanoErg: Long,
       liliumFeeAddress: Address,
-      liliumFeeNanoErg: Long,
+      liliumFeePercent: Long,
       minTxOperatorFeeNanoErg: Long,
       minerFee: Long
   ): ErgoContract = {
@@ -103,7 +103,8 @@ class ContractCompile(ctx: BlockchainContext) {
         .item("_singletonToken", singletonToken.getId.getBytes)
         .item("_priceOfNFT", priceOfNFTNanoErg)
         .item("_liliumSigmaProp", liliumFeeAddress.getPublicKey)
-        .item("_liliumFee", liliumFeeNanoErg)
+        .item("_liliumFeeNum", liliumFeePercent)
+        .item("_liliumFeeDenom", 100)
         .item("_txOperatorFee", minTxOperatorFeeNanoErg)
         .item("_minerFee", minerFee)
         .build(),

--- a/src/test/scala/main/init.scala
+++ b/src/test/scala/main/init.scala
@@ -121,7 +121,7 @@ object init extends App {
     issuerMetaDataMap = issuerTree.getMap,
     priceOfNFTNanoErg = collectionFromJson.priceOfNFTNanoErg,
     liliumFeeAddress = Address.create(serviceConf.liliumFeeAddress),
-    liliumFeeNanoErg = serviceConf.liliumFeeNanoErg,
+    liliumFeePercent = serviceConf.liliumFeePercent,
     minTxOperatorFeeNanoErg = serviceConf.minTxOperatorFeeNanoErg,
     minerFee = serviceConf.minerFeeNanoErg
   )

--- a/src/test/scala/main/liliumTest.scala
+++ b/src/test/scala/main/liliumTest.scala
@@ -336,7 +336,7 @@ object stateBoxConstantsTest extends App {
   )
   val priceOfNFTNanoErg = collectionFromJson.priceOfNFTNanoErg
   val liliumFeeAddress = Address.create(serviceConf.liliumFeeAddress)
-  val liliumFeeNanoErg = serviceConf.liliumFeeNanoErg
+  val liliumFeePercent = serviceConf.liliumFeePercent
   val minTxOperatorFeeNanoErg = serviceConf.minTxOperatorFeeNanoErg
   val minerFee = serviceConf.minerFeeNanoErg
 
@@ -350,7 +350,7 @@ object stateBoxConstantsTest extends App {
     singletonToken,
     priceOfNFTNanoErg,
     liliumFeeAddress,
-    liliumFeeNanoErg,
+    liliumFeePercent,
     minTxOperatorFeeNanoErg,
     minerFee
   )
@@ -392,6 +392,12 @@ object stateBoxConstantsTest extends App {
   )
     .toAddress(this.ctx.getNetworkType)
 
+  val liliumFeeValue =
+    stateContract.getErgoTree.constants(30).value.asInstanceOf[Long]
+
+  val priceOfNFTNanoErgDecoded =
+    stateContract.getErgoTree.constants(29).value.asInstanceOf[Long]
+
   println(s"Miner Fee: $minerFee, Decoded: $minerFeeDecoded")
   println(
     s"Collection Token: ${collectionToken.getId.toString}, Decoded: ${mockCollectionToken.getId.toString}"
@@ -399,9 +405,18 @@ object stateBoxConstantsTest extends App {
   println(
     s"Artist Address: ${artistAddress.toString}, Decoded: ${artistAddressDecoded.toString}"
   )
-  println(s"Lilium Fee: $liliumFeeNanoErg, Decoded: $liliumFeeDecoded")
+
+  println(
+    s"NFT Cost: ${collectionFromJson.priceOfNFTNanoErg}, Decoded: $priceOfNFTNanoErgDecoded"
+  )
+
+  println(
+    s"Lilium Fee Numerator: ${serviceConf.liliumFeePercent}, Decoded: ${(liliumFeeValue.toDouble / collectionFromJson.priceOfNFTNanoErg.toDouble) * 100}"
+  )
   println(
     s"Lilium Fee Address: ${liliumFeeAddress.toString}, Decoded: ${liliumFeeAddressDecoded.toString}"
   )
+
+//  stateContract.getErgoTree.constants.foreach(o => println(o.value))
 
 }


### PR DESCRIPTION
@mgpai22 Please review this pull-request.

Changes:
- added percentage fee numerator and denominator compile time constants to contract
- modified lilium fee condition in contract code to include the percentage fee:

Remarks:
- since NFTPrice is still going to the artist, percentage fee from lilium is effectively being paid for by the buyer
- we also want to give the artist the option of paying this fee for the buyer instead so we should add option for this in the contract later.